### PR TITLE
Update `theme.json`

### DIFF
--- a/wp-content/themes/fooclient/theme.json
+++ b/wp-content/themes/fooclient/theme.json
@@ -1,5 +1,6 @@
 {
-  "version": 1,
+  "version": 2,
+  "$schema": "https://schemas.wp.org/trunk/theme.json",
   "settings": {
     "color": {
       "custom": false,
@@ -22,15 +23,31 @@
       ]
     },
     "spacing": {
-      "customMargin": false,
-      "customPadding": false,
-      "units": []
+      "margin": false,
+      "padding": false,
+      "units": ["px", "em", "rem", "vh", "vw", "%"]
     },
     "typography": {
       "customFontSize": false,
-      "customLineHeight": false,
+      "lineHeight": false,
       "dropCap": false,
-      "fontSizes": []
+      "fontSizes": [
+        {
+          "slug": "small",
+          "size": "1rem",
+          "name": "Small"
+        },
+        {
+          "slug": "medium",
+          "size": "1.5rem",
+          "name": "medium"
+        },
+        {
+          "slug": "large",
+          "size": "2rem",
+          "name": "Large"
+        }
+      ]
     }
   }
 }


### PR DESCRIPTION
- Update `theme.json` to version 2 which is WP 5.9+ compatible. See [ref](https://developer.wordpress.org/themes/advanced-topics/theme-json/#font-size:~:text=There%20are%20important%20differences%20between%20what%20is%20available%20for%20theme.json%20in%20WordPress%20version%205.8%20(version%201)%2C%20WordPress%205.9%20and%20newer%20(version%202)%2C%20and%20the%20Gutenberg%20plugin%20(experimental%20features).).
- Include [`$schema`](https://make.wordpress.org/themes/2021/11/30/theme-json-schema/) to validate props in `theme.json`.